### PR TITLE
Fix cannot create new notes

### DIFF
--- a/components/EditorPage.server.js
+++ b/components/EditorPage.server.js
@@ -16,23 +16,17 @@ export default function EditNote({ login, router, searchText }) {
 
   let note =
     selectedId != null
-      ? useData(apiKey, url =>
-          fetch(url).then(res => res.json())
-        )
+      ? useData(apiKey, url => fetch(url).then(res => res.json()))
       : defaultNote
 
   note = note || defaultNote
 
-  const isCreator = note.created_by === login
+  const isCreator = !selectedId || note.created_by === login
 
   return (
     <Page login={login} searchText={searchText}>
       <Suspense fallback={<NoteSkeleton isEditing={isCreator} />}>
-        <NoteUI
-          note={note}
-          isEditing={isCreator}
-          selectedId={selectedId}
-        />
+        <NoteUI note={note} isEditing={isCreator} selectedId={selectedId} />
       </Suspense>
     </Page>
   )

--- a/components/NoteUI.server.js
+++ b/components/NoteUI.server.js
@@ -5,7 +5,7 @@ import AuthButton from './AuthButton.server'
 
 export default function NoteUI({ note, isEditing, login }) {
   const { id, title, body, updated_at, created_by: createdBy } = note
-  const updatedAt = new Date(updated_at)
+  const updatedAt = new Date(updated_at || 0)
 
   if (isEditing) {
     return <NoteEditor noteId={id} initialTitle={title} initialBody={body} />


### PR DESCRIPTION
For the note creation page (/note/edit), an empty note is always provided hence `updated_at` is undefined. And in that case `isCreator` should always be true.